### PR TITLE
Short-circuit validateScope so forbidden requests cannot mutate

### DIFF
--- a/src/main/kotlin/com/mfrancza/jwtrevocation/manager/plugins/Routing.kt
+++ b/src/main/kotlin/com/mfrancza/jwtrevocation/manager/plugins/Routing.kt
@@ -35,8 +35,9 @@ fun Application.configureRouting() {
             suspend fun RoutingContext.validateScope(scope: String, block: suspend () -> Unit) {
                 if (call.principal<JWTPrincipal>()?.hasScope(scope) != true) {
                     call.respond(HttpStatusCode.Forbidden, "Access denied")
+                } else {
+                    block()
                 }
-                block()
             }
             route("/revoked") {
                 post {

--- a/src/test/kotlin/com/mfrancza/jwtrevocation/manager/ApplicationTest.kt
+++ b/src/test/kotlin/com/mfrancza/jwtrevocation/manager/ApplicationTest.kt
@@ -244,8 +244,37 @@ class ApplicationTest {
         }
 
         //try to delete a rule, which should result in a 403 since the client only has read permissions
-        readOnlyClient.delete("/rules/${expectedRules.first().ruleId}").apply {
+        val protectedRule = expectedRules.first()
+        readOnlyClient.delete("/rules/${protectedRule.ruleId}").apply {
             assertEquals(HttpStatusCode.Forbidden, status)
+        }
+
+        //the forbidden delete must not have mutated the store
+        client.get("/rules/${protectedRule.ruleId}").apply {
+            assertEquals(HttpStatusCode.OK, status, "Rule must still exist after a forbidden delete")
+            assertEquals(protectedRule, this.body<Rule>())
+        }
+
+        //try to create a rule, which should also be forbidden and must not mutate the store
+        val rejectedRule = Rule(
+            ruleExpires = Instant.now().plus(1, ChronoUnit.DAYS).epochSecond,
+            sub = listOf(
+                StringEquals(
+                    value = "should-not-be-created.mfrancza.com"
+                )
+            )
+        )
+        readOnlyClient.post("/rules") {
+            contentType(ContentType.Application.Json)
+            setBody(rejectedRule)
+        }.apply {
+            assertEquals(HttpStatusCode.Forbidden, status)
+        }
+
+        client.get("/rules").apply {
+            assertEquals(HttpStatusCode.OK, status)
+            val rules = this.body<PartialList>().rules
+            validateExpectedRules(expectedRules, rules)
         }
 
         //create an unauthenticated client


### PR DESCRIPTION
## Summary
- `validateScope` in `plugins/Routing.kt` called `call.respond(Forbidden)` but did not return, so the protected block ran unconditionally. A read-only token sending `DELETE /rules/{id}` actually removed the rule from the store; the second `call.respond(...)` then threw because a response had already been committed. Same hazard on `POST /rules`.
- Wraps `block()` in `else` so it only runs when the scope check passes.
- Extends `ApplicationTest.testRuleManagement` to re-read the target rule after a forbidden `DELETE` and to attempt a forbidden `POST /rules` and re-list — both would have failed before the fix.

## Test plan
- [x] `./gradlew test` — `ApplicationTest` and persistence/security suites all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)