### PR TITLE
Stop double-responding when /rules/{ruleId} is not found

### DIFF
--- a/src/main/kotlin/com/mfrancza/jwtrevocation/manager/plugins/Routing.kt
+++ b/src/main/kotlin/com/mfrancza/jwtrevocation/manager/plugins/Routing.kt
@@ -91,15 +91,23 @@ fun Application.configureRouting() {
                     get {
                         validateScope("GET:/rules/{ruleId}") {
                             val ruleId = call.parameters["ruleId"] ?: throw IllegalArgumentException()
-                            val rule = ruleStore.read(ruleId) ?: call.respond(HttpStatusCode.NotFound, "Rule not found")
-                            call.respond(rule)
+                            val rule = ruleStore.read(ruleId)
+                            if (rule != null) {
+                                call.respond(rule)
+                            } else {
+                                call.respond(HttpStatusCode.NotFound, "Rule not found")
+                            }
                         }
                     }
                     delete {
                         validateScope("DELETE:/rules/{ruleId}") {
                             val ruleId = call.parameters["ruleId"] ?: throw IllegalArgumentException()
-                            val rule = ruleStore.delete(ruleId) ?: call.respond(HttpStatusCode.NotFound, "Rule not found")
-                            call.respond(rule)
+                            val rule = ruleStore.delete(ruleId)
+                            if (rule != null) {
+                                call.respond(rule)
+                            } else {
+                                call.respond(HttpStatusCode.NotFound, "Rule not found")
+                            }
                         }
                     }
                 }

--- a/src/test/kotlin/com/mfrancza/jwtrevocation/manager/ApplicationTest.kt
+++ b/src/test/kotlin/com/mfrancza/jwtrevocation/manager/ApplicationTest.kt
@@ -287,6 +287,37 @@ class ApplicationTest {
 
     }
 
+    @Test
+    fun testMissingRuleReturnsNotFound() = testApplication {
+        val issuer = "testIssuer"
+        val audience = "testAudience"
+        val jwtSecret = "testSecret"
+
+        application(makeJwtRevocationManager(
+            SecuritySettings(audience, issuer, SecuritySettings.HS256(jwtSecret)),
+            DataStoreSettings("in-memory", "", "")
+        ))
+
+        val token = JWT.create()
+            .withAudience(audience)
+            .withIssuer(issuer)
+            .withClaim("scope", "GET:/rules/{ruleId} DELETE:/rules/{ruleId}")
+            .withExpiresAt(Date(System.currentTimeMillis() + 60000))
+            .sign(Algorithm.HMAC256(jwtSecret))
+
+        val client = createClient {
+            install(ContentNegotiation) { json() }
+            install(Auth) { bearer { loadTokens { BearerTokens(token, "NotUsed") } } }
+        }
+
+        client.get("/rules/does-not-exist").apply {
+            assertEquals(HttpStatusCode.NotFound, status)
+        }
+        client.delete("/rules/does-not-exist").apply {
+            assertEquals(HttpStatusCode.NotFound, status)
+        }
+    }
+
     private fun validateExpectedRules(expectedRules: List<Rule>, actualRules: List<Rule>) {
         assertEquals(expectedRules.size, actualRules.size, "The number of rules should be the same")
         expectedRules.forEach {


### PR DESCRIPTION
## Summary
- `GET` and `DELETE` on `/rules/{ruleId}` used `val rule = ruleStore.read(id) ?: call.respond(NotFound, ...)`. Because `call.respond` returns `Unit`, the Elvis branch did not exit — `rule` became `Any?` and the next `call.respond(rule)` either threw on a committed response or sent a spurious body after the 404.
- Replaces both handlers with an explicit `if/else` so exactly one response is sent.
- Adds `testMissingRuleReturnsNotFound` covering both verbs against an unknown id.

## Test plan
- [x] `./gradlew test` — new test passes; existing suites unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)