### PR TITLE
Make JDBCRuleStore.delete atomic and respect row count

### DIFF
--- a/src/main/kotlin/com/mfrancza/jwtrevocation/manager/persistence/JDBCRuleStore.kt
+++ b/src/main/kotlin/com/mfrancza/jwtrevocation/manager/persistence/JDBCRuleStore.kt
@@ -93,15 +93,13 @@ class JDBCRuleStore(url: String, user: String = "", password: String = "") : Rul
     }
 
     override fun delete(ruleId: String): Rule? {
-        val rule = read(ruleId)
-        if (rule != null) {
-            transaction(db) {
-                Rules.deleteWhere {
-                    Rules.ruleId.eq(ruleId)
-                }
-            }
+        return transaction(db) {
+            val rule = Rules.selectAll().where {
+                Rules.ruleId.eq(ruleId)
+            }.map { rowToRule(it) }.singleOrNull() ?: return@transaction null
+            val deleted = Rules.deleteWhere { Rules.ruleId.eq(ruleId) }
+            if (deleted > 0) rule else null
         }
-        return rule
     }
 
     override fun list(cursor: String?, limit: Int?): PartialList {


### PR DESCRIPTION
## Summary
- `delete()` ran `read()` and `deleteWhere` in two separate transactions and ignored the row-count returned by `deleteWhere`. Two concurrent deletes for the same `ruleId` could both return the rule even though only one DB row was actually removed; a successful read followed by a no-op delete still returned the rule.
- Folds the lookup and delete into a single transaction and only returns the rule when `deleteWhere` reports a row removed.
- No new test — the existing single-threaded coverage in `RuleStoreTest` is preserved and reproducing the race deterministically would add disproportionate complexity for this fix.

## Test plan
- [x] `./gradlew test` — `RuleStoreTest`/`JDBCRuleStoreTest` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)