### PR TITLE
Require GET:/metrics-micrometer scope on the metrics endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,7 @@ Note: `validateScope` calls `call.respond(Forbidden)` on failure but does **not*
 - `GET /ruleset` — full `RuleSet` for clients to cache; 5-second `Cache-Control: max-age`
 - `POST /revoked` — server-side check: accepts `Claims`, returns whether any rule matches; 5-second cache
 - `GET/POST /rules`, `GET/DELETE /rules/{ruleId}` — admin CRUD. No update; mutate by delete+create. `POST` rejects rules with a pre-set `ruleId`.
+- `GET /metrics-micrometer` — Prometheus scrape endpoint, also scope-gated (`GET:/metrics-micrometer`). Defined in `plugins/Monitoring.kt`, not `Routing.kt`, so it uses an inline `hasScope` check rather than the local `validateScope` helper.
 
 ### Rule store
 

--- a/src/main/kotlin/com/mfrancza/jwtrevocation/manager/plugins/Monitoring.kt
+++ b/src/main/kotlin/com/mfrancza/jwtrevocation/manager/plugins/Monitoring.kt
@@ -1,10 +1,13 @@
 package com.mfrancza.jwtrevocation.manager.plugins
 
 import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.Application
 import io.ktor.server.application.call
 import io.ktor.server.application.install
 import io.ktor.server.auth.authenticate
+import io.ktor.server.auth.jwt.JWTPrincipal
+import io.ktor.server.auth.principal
 import io.ktor.server.metrics.micrometer.MicrometerMetrics
 import io.ktor.server.plugins.callid.CallId
 import io.ktor.server.plugins.callid.callIdMdc
@@ -39,6 +42,10 @@ fun Application.configureMonitoring() {
     routing {
         authenticate("auth-jwt") {
             get("/metrics-micrometer") {
+                if (call.principal<JWTPrincipal>()?.hasScope("GET:/metrics-micrometer") != true) {
+                    call.respond(HttpStatusCode.Forbidden, "Access denied")
+                    return@get
+                }
                 call.respond(appMicrometerRegistry.scrape())
             }
         }

--- a/src/test/kotlin/com/mfrancza/jwtrevocation/manager/ApplicationTest.kt
+++ b/src/test/kotlin/com/mfrancza/jwtrevocation/manager/ApplicationTest.kt
@@ -347,6 +347,39 @@ class ApplicationTest {
         }
     }
 
+    @Test
+    fun testMetricsRequiresScope() = testApplication {
+        val issuer = "testIssuer"
+        val audience = "testAudience"
+        val jwtSecret = "testSecret"
+
+        application(makeJwtRevocationManager(
+            SecuritySettings(audience, issuer, SecuritySettings.HS256(jwtSecret)),
+            DataStoreSettings("in-memory", "", "")
+        ))
+
+        fun tokenWithScope(scope: String) = JWT.create()
+            .withAudience(audience)
+            .withIssuer(issuer)
+            .withClaim("scope", scope)
+            .withExpiresAt(Date(System.currentTimeMillis() + 60000))
+            .sign(Algorithm.HMAC256(jwtSecret))
+
+        val withMetricsScope = createClient {
+            install(Auth) { bearer { loadTokens { BearerTokens(tokenWithScope("GET:/metrics-micrometer"), "NotUsed") } } }
+        }
+        val withoutMetricsScope = createClient {
+            install(Auth) { bearer { loadTokens { BearerTokens(tokenWithScope("GET:/ruleset"), "NotUsed") } } }
+        }
+
+        withMetricsScope.get("/metrics-micrometer").apply {
+            assertEquals(HttpStatusCode.OK, status)
+        }
+        withoutMetricsScope.get("/metrics-micrometer").apply {
+            assertEquals(HttpStatusCode.Forbidden, status)
+        }
+    }
+
     private fun validateExpectedRules(expectedRules: List<Rule>, actualRules: List<Rule>) {
         assertEquals(expectedRules.size, actualRules.size, "The number of rules should be the same")
         expectedRules.forEach {


### PR DESCRIPTION
## Summary
- `GET /metrics-micrometer` lived inside `authenticate("auth-jwt")` but had no scope check, so any caller with a valid token for this server could scrape Prometheus metrics.
- Adds an inline `hasScope("GET:/metrics-micrometer")` check that responds 403 when missing. The check is inline rather than calling the local `validateScope` helper in `Routing.kt`, since that helper isn't visible from `Monitoring.kt` — a shared extraction is out of scope for this fix.
- Updates `CLAUDE.md` to document the new scope and its location.
- Adds `testMetricsRequiresScope` covering both authorized and forbidden cases.

## Test plan
- [x] `./gradlew test` — new test passes; existing suites unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)