### PR TITLE
Install StatusPages and let store-level validation surface as 400

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ Ktor (Netty) server using Koin for DI. `Application.kt::makeJwtRevocationManager
 
 1. `DependencyInjection` — binds a single `RuleStore` based on `DataStoreSettings.url` prefix (`in-memory` → `InMemoryRuleStore`, `jdbc` → `JDBCRuleStore`). `makeRuleStore` is the dispatch point — add new store types here.
 2. `Security` — installs the `auth-jwt` provider. The JWT validator calls `notRevoked(ruleStore.ruleSet())` from `jwt-revocation-ktor-server-auth`, so **the manager's own API enforces its own revocation rules against incoming admin tokens**. A rule that matches the admin's token will lock them out.
-3. `Serialization`, `HTTP`, `Monitoring`, `Routing`.
+3. `Serialization`, `StatusPages`, `HTTP`, `Monitoring`, `Routing`. `StatusPages` maps `BadRequestException` and `IllegalArgumentException` (e.g. the one thrown by `RuleStore.create` when `ruleId` is non-null) to 400; everything else to 500 with a generic body.
 
 ### Authorization model
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,6 +64,7 @@ dependencies {
     implementation("io.ktor:ktor-server-default-headers-jvm:$ktor_version")
     implementation("io.ktor:ktor-server-call-logging-jvm:$ktor_version")
     implementation("io.ktor:ktor-server-call-id-jvm:$ktor_version")
+    implementation("io.ktor:ktor-server-status-pages-jvm:$ktor_version")
     implementation("io.ktor:ktor-server-metrics-micrometer-jvm:$ktor_version")
     implementation("io.micrometer:micrometer-registry-prometheus:$prometeus_version")
     implementation("io.ktor:ktor-server-netty-jvm:$ktor_version")

--- a/src/main/kotlin/com/mfrancza/jwtrevocation/manager/Application.kt
+++ b/src/main/kotlin/com/mfrancza/jwtrevocation/manager/Application.kt
@@ -8,6 +8,7 @@ import com.mfrancza.jwtrevocation.manager.plugins.configureMonitoring
 import com.mfrancza.jwtrevocation.manager.plugins.configureRouting
 import com.mfrancza.jwtrevocation.manager.plugins.configureSecurity
 import com.mfrancza.jwtrevocation.manager.plugins.configureSerialization
+import com.mfrancza.jwtrevocation.manager.plugins.configureStatusPages
 import com.mfrancza.jwtrevocation.manager.plugins.makeRuleStore
 import io.ktor.server.application.Application
 import io.ktor.server.engine.embeddedServer
@@ -19,6 +20,7 @@ fun makeJwtRevocationManager(securitySettings: SecuritySettings, dataStoreSettin
         configureDependencyInjection(dataStoreSettings)
         configureSecurity(securitySettings)
         configureSerialization()
+        configureStatusPages()
         configureHTTP()
         configureMonitoring()
         configureRouting()

--- a/src/main/kotlin/com/mfrancza/jwtrevocation/manager/plugins/Routing.kt
+++ b/src/main/kotlin/com/mfrancza/jwtrevocation/manager/plugins/Routing.kt
@@ -22,7 +22,6 @@ import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
 import org.koin.ktor.ext.inject
-import java.lang.IllegalArgumentException
 import java.time.Instant
 
 fun Application.configureRouting() {
@@ -82,9 +81,6 @@ fun Application.configureRouting() {
                 post {
                     validateScope("POST:/rules") {
                         val newRule = call.receive<Rule>()
-                        if (newRule.ruleId != null) {
-                            throw IllegalArgumentException()
-                        }
                         call.respond(ruleStore.create(newRule))
                     }
                 }

--- a/src/main/kotlin/com/mfrancza/jwtrevocation/manager/plugins/StatusPages.kt
+++ b/src/main/kotlin/com/mfrancza/jwtrevocation/manager/plugins/StatusPages.kt
@@ -3,9 +3,11 @@ package com.mfrancza.jwtrevocation.manager.plugins
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
+import io.ktor.server.application.log
 import io.ktor.server.plugins.BadRequestException
 import io.ktor.server.plugins.statuspages.StatusPages
 import io.ktor.server.response.respond
+import kotlinx.coroutines.CancellationException
 
 fun Application.configureStatusPages() {
     install(StatusPages) {
@@ -15,7 +17,10 @@ fun Application.configureStatusPages() {
         exception<IllegalArgumentException> { call, cause ->
             call.respond(HttpStatusCode.BadRequest, cause.message ?: "Bad request")
         }
-        exception<Throwable> { call, _ ->
+        exception<Throwable> { call, cause ->
+            //structured cancellation must propagate; never swallow it as a 500
+            if (cause is CancellationException) throw cause
+            call.application.log.error("Unhandled exception for ${call.request.local.method.value} ${call.request.local.uri}", cause)
             call.respond(HttpStatusCode.InternalServerError, "Internal server error")
         }
     }

--- a/src/main/kotlin/com/mfrancza/jwtrevocation/manager/plugins/StatusPages.kt
+++ b/src/main/kotlin/com/mfrancza/jwtrevocation/manager/plugins/StatusPages.kt
@@ -1,0 +1,22 @@
+package com.mfrancza.jwtrevocation.manager.plugins
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import io.ktor.server.plugins.BadRequestException
+import io.ktor.server.plugins.statuspages.StatusPages
+import io.ktor.server.response.respond
+
+fun Application.configureStatusPages() {
+    install(StatusPages) {
+        exception<BadRequestException> { call, cause ->
+            call.respond(HttpStatusCode.BadRequest, cause.message ?: "Bad request")
+        }
+        exception<IllegalArgumentException> { call, cause ->
+            call.respond(HttpStatusCode.BadRequest, cause.message ?: "Bad request")
+        }
+        exception<Throwable> { call, _ ->
+            call.respond(HttpStatusCode.InternalServerError, "Internal server error")
+        }
+    }
+}

--- a/src/test/kotlin/com/mfrancza/jwtrevocation/manager/ApplicationTest.kt
+++ b/src/test/kotlin/com/mfrancza/jwtrevocation/manager/ApplicationTest.kt
@@ -347,6 +347,58 @@ class ApplicationTest {
         }
     }
 
+    @Test
+    fun testBadRequestsReturn400() = testApplication {
+        val issuer = "testIssuer"
+        val audience = "testAudience"
+        val jwtSecret = "testSecret"
+
+        application(makeJwtRevocationManager(
+            SecuritySettings(audience, issuer, SecuritySettings.HS256(jwtSecret)),
+            DataStoreSettings("in-memory", "", "")
+        ))
+
+        val token = JWT.create()
+            .withAudience(audience)
+            .withIssuer(issuer)
+            .withClaim("scope", "GET:/rules POST:/rules")
+            .withExpiresAt(Date(System.currentTimeMillis() + 60000))
+            .sign(Algorithm.HMAC256(jwtSecret))
+
+        val client = createClient {
+            install(ContentNegotiation) { json() }
+            install(Auth) { bearer { loadTokens { BearerTokens(token, "NotUsed") } } }
+        }
+
+        //a rule with a pre-set ruleId must be rejected as a client error, not surface as 500
+        val ruleWithId = Rule(
+            ruleId = "client-supplied-id",
+            ruleExpires = Instant.now().plus(1, ChronoUnit.DAYS).epochSecond,
+            iss = listOf(StringEquals(value = "bad.mfrancza.com"))
+        )
+        client.post("/rules") {
+            contentType(ContentType.Application.Json)
+            setBody(ruleWithId)
+        }.apply {
+            assertEquals(HttpStatusCode.BadRequest, status)
+        }
+
+        //a non-numeric limit must come back as 400 not 500
+        client.get("/rules") {
+            this.parameter("limit", "not-a-number")
+        }.apply {
+            assertEquals(HttpStatusCode.BadRequest, status)
+        }
+
+        //a malformed JSON body must come back as 400 not 500
+        client.post("/rules") {
+            contentType(ContentType.Application.Json)
+            setBody("{ not valid json")
+        }.apply {
+            assertEquals(HttpStatusCode.BadRequest, status)
+        }
+    }
+
     private fun validateExpectedRules(expectedRules: List<Rule>, actualRules: List<Rule>) {
         assertEquals(expectedRules.size, actualRules.size, "The number of rules should be the same")
         expectedRules.forEach {


### PR DESCRIPTION
## Summary
- Installs the `StatusPages` plugin (new `plugins/StatusPages.kt`, new `ktor-server-status-pages-jvm` dep) so exceptions map to meaningful status codes instead of 500. Mapping:
  - `BadRequestException` → 400 (passes the message)
  - `IllegalArgumentException` → 400 (passes the message)
  - any other `Throwable` → 500 with a sanitized body
- Drops the redundant `if (newRule.ruleId != null) throw IllegalArgumentException()` in `POST /rules`. `RuleStore.create` already throws `IllegalArgumentException("New rules must not have a ruleId set")`, which now surfaces as a 400 with the same message.
- Updates `CLAUDE.md` plugin order.
- Adds `testBadRequestsReturn400` covering the ruleId case and a non-numeric `limit`.

## Test plan
- [x] `./gradlew test` — new test passes; existing suites unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)