### PR TITLE
Detect end-of-table in JDBCRuleStore.list with limit+1 lookahead

### DIFF
--- a/src/main/kotlin/com/mfrancza/jwtrevocation/manager/persistence/JDBCRuleStore.kt
+++ b/src/main/kotlin/com/mfrancza/jwtrevocation/manager/persistence/JDBCRuleStore.kt
@@ -106,33 +106,28 @@ class JDBCRuleStore(url: String, user: String = "", password: String = "") : Rul
 
     override fun list(cursor: String?, limit: Int?): PartialList {
         val offset = cursor?.toInt() ?: 0
-        val rules = transaction(db) {
-            Rules.selectAll()
-                .orderBy(Rules.ruleId)
-                .let {
-                    if (limit != null) {
-                        it.limit(limit).offset(offset.toLong())
-                    } else {
-                        it
-                    }
-                }
-                .map { rowToRule(it) }
-                .let {
-                    if (limit == null) {
-                        it.subList(offset, it.size)
-                    } else {
-                        it
-                    }
-                }
+        if (limit == null) {
+            val all = transaction(db) {
+                Rules.selectAll()
+                    .orderBy(Rules.ruleId)
+                    .map { rowToRule(it) }
+            }
+            return PartialList(all.subList(offset.coerceAtMost(all.size), all.size), null)
         }
 
+        //fetch one extra row to detect whether another page exists without
+        //handing out a cursor that points past the last row
+        val rows = transaction(db) {
+            Rules.selectAll()
+                .orderBy(Rules.ruleId)
+                .limit(limit + 1)
+                .offset(offset.toLong())
+                .map { rowToRule(it) }
+        }
+        val hasMore = rows.size > limit
         return PartialList(
-            rules,
-            if (limit != null && rules.size == limit) {
-                (offset + limit).toString()
-            } else {
-                null
-            }
+            rules = if (hasMore) rows.take(limit) else rows,
+            cursor = if (hasMore) (offset + limit).toString() else null
         )
     }
 

--- a/src/test/kotlin/com/mfrancza/jwtrevocation/manager/persistence/RuleStoreTest.kt
+++ b/src/test/kotlin/com/mfrancza/jwtrevocation/manager/persistence/RuleStoreTest.kt
@@ -101,6 +101,26 @@ abstract class RuleStoreTest {
     }
 
     /**
+     * Test that asking for exactly as many rules as exist does not yield a stale cursor
+     */
+    @Test
+    fun testListWithLimitEqualToRemaining() {
+        repeat(3) { i ->
+            ruleStore.create(Rule(
+                ruleExpires = 1667156265,
+                iss = listOf(StringEquals(value = "exact-$i.mfrancza.com"))
+            ))
+        }
+
+        //some tests share a backing store (e.g. JDBC H2 in-memory), so derive the total
+        val total = ruleStore.list().rules.size
+
+        val page = ruleStore.list(cursor = null, limit = total)
+        assertEquals(total, page.rules.size, "Should return every rule in a single page")
+        assertNull(page.cursor, "Cursor must be null when the page exhausts the store")
+    }
+
+    /**
      * Test that deleting a rule removes it from the rule store
      */
     @Test


### PR DESCRIPTION
## Summary
- `JDBCRuleStore.list` issued a cursor whenever the returned page exactly filled the requested limit, even when the page was the last one in the table. The next call would return `PartialList(empty, null)` — a wasted round trip and a violation of `RuleStore.list`'s contract ("a cursor pointing to the next rule if there are additional rules").
- Queries `limit + 1` rows and uses the presence of the extra row as the "more" signal; falls back to the existing slicing path when `limit` is `null`.
- Adds `RuleStoreTest.testListWithLimitEqualToRemaining`. Note the JDBC test class shares an H2 in-memory DB across test methods, so the assertion derives the total dynamically rather than assuming a clean store.

## Test plan
- [x] `./gradlew test` — new test passes; existing pagination tests unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)